### PR TITLE
Unexpected character

### DIFF
--- a/spring-security-client/src/main/resources/application.yml
+++ b/spring-security-client/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
             client-secret: secret
             authorization-grant-type: authorization_code
             redirect-uri: "http://127.0.0.1:8080/login/oauth2/code/{registrationId}"
-            scope: openid´
+            scope: openid
             client-name: api-client-oidc
           api-client-authorization-code:
             provider: spring


### PR DESCRIPTION
"Caused by: java.lang.IllegalArgumentException: scope "openid´" contains invalid characters"
this ' ´ ' apparently it can break some applications... I removed it from mine and I was able to upload it normally... it facilitates the environment for those who want to clone this project ;)